### PR TITLE
Add support for ignoring files by glob pattern

### DIFF
--- a/StudioHelper.js
+++ b/StudioHelper.js
@@ -11,7 +11,7 @@ Promise.longStackTraces();
 const API_URL = '/studioapi/v2/',
       CHUNK_SIZE = '900000',
       CREDENTIALS_FILE = '.studio-credentials',
-      IGNORE_FILE = '.studioignore',
+      IGNORE_FILE = '.studio-ignore',
       LONG_SESSION = 1;
 
 /**

--- a/StudioHelper.js
+++ b/StudioHelper.js
@@ -3,13 +3,15 @@
 let request = require('request'),
     mime = require('mime-types'),
     Promise = require('bluebird'),
-    fs = require('fs');
+    fs = require('fs'),
+    glob = require('glob');
 
 Promise.longStackTraces();
 
 const API_URL = '/studioapi/v2/',
       CHUNK_SIZE = '900000',
       CREDENTIALS_FILE = '.studio-credentials',
+      IGNORE_FILE = '.studioignore',
       LONG_SESSION = 1;
 
 /**
@@ -71,7 +73,14 @@ class StudioHelper {
       this.credentialsFile = CREDENTIALS_FILE;
     }
 
+    if (settings.ignoreFile) {
+      this.ignoreFile = settings.ignoreFile;
+    } else {
+      this.ignoreFile = IGNORE_FILE;
+    }
+
     this.credentials = this._getCredentials();
+    this.ignorePattern = this._getIgnorePattern();
 
     if (this.credentials && this.credentials.authToken) {
       this.setAuthToken(this.credentials.authToken);
@@ -103,6 +112,23 @@ class StudioHelper {
     }
 
     return data;
+  }
+
+  /**
+   * @private
+   */
+  _getIgnorePattern() {
+    let pattern = null;
+
+    try {
+      let patterns = fs.readFileSync(this.ignoreFile, 'utf-8').split(/\r?\n/).filter(Boolean);
+      if (patterns.length) {
+        pattern = `+(${patterns.join('|')})`;
+      }
+    } catch (e) {
+    }
+
+    return pattern;
   }
 
   /**
@@ -744,7 +770,8 @@ class StudioHelper {
 
   uploadFilesInFolders(folders) {
     let self = this,
-        foldersData = [];
+        foldersData = [],
+        ignoredFiles = [];
 
     for (let i = 0, l = folders.length; i < l; i++) {
       try {
@@ -756,7 +783,16 @@ class StudioHelper {
           files: []
         };
 
-        let localFiles = fs.readdirSync(folders[i].localFolder);
+        if (typeof this.ignorePattern === 'string') {
+          ignoredFiles = glob.sync(this.ignorePattern, {
+            cwd: folder.localFolder,
+            dot: true
+          });
+        }
+
+        let localFiles = fs.readdirSync(folder.localFolder).filter(function(file) {
+          return ignoredFiles.indexOf(file) === -1;
+        });
 
         for (let j = 0, l2 = localFiles.length; j < l2; j++) {
           let itemStat = fs.lstatSync(folder.localFolder + '/' + localFiles[j]);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bluebird": "^3.4.5",
     "inquirer": "^1.1.3",
     "mime-types": "^2.1.11",
+    "node-glob": "^1.2.0",
     "prompt": "^1.0.0",
     "request": "^2.74.0"
   },


### PR DESCRIPTION
Resolve issue #1 by adding support for ignore file, which accepts glob patterns similar to ".gitignore". Ignoring folders is not possible since folders are always specified explicitly in the Studio settings. The default ignore file name is ".studioignore".
